### PR TITLE
Change storing Repos in RepoDict and some cleaning of code

### DIFF
--- a/libdnf/package.hpp
+++ b/libdnf/package.hpp
@@ -3,29 +3,28 @@
 
 
 #include <string>
-using namespace std;
 
 
 class Package {
     public:
         Package() {};
         virtual ~Package() = default;
-        string name;
+        std::string name;
 };
 
 
 class RPMPackage : public Package {
     public:
         RPMPackage() {};
-        string version;
-        string release;
+        std::string version;
+        std::string release;
 };
 
 
 class ModulePackage : public Package {
     public:
         ModulePackage() {};
-        string stream;
+        std::string stream;
         long long version;
 };
 

--- a/libdnf/repo.cpp
+++ b/libdnf/repo.cpp
@@ -23,14 +23,14 @@ const vector<string>& Repo::get_baseurl() {
 }
 
 
-void RepoDict::set_repos(const map<string, Repo>& repos) {
+void RepoDict::set_repos(const map<string, shared_ptr<Repo>> & repos) {
     _repos = repos;
 }
 
-const map<string, Repo>& RepoDict::get_repos() {
+const map<string, shared_ptr<Repo>> & RepoDict::get_repos() {
     return _repos;
 }
 
-void RepoDict::add_repo(Repo repo) {
-    _repos[repo.get_repoid()] = repo;
+void RepoDict::add_repo(shared_ptr<Repo> & repo) {
+    _repos[repo->get_repoid()] = repo;
 }

--- a/libdnf/repo.cpp
+++ b/libdnf/repo.cpp
@@ -1,9 +1,3 @@
-#include <string>
-#include <vector>
-#include <map>
-#include <functional>
-#include <iostream>
-
 #include "repo.hpp"
 
 using namespace std;

--- a/libdnf/repo.hpp
+++ b/libdnf/repo.hpp
@@ -4,8 +4,6 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <functional>
-#include <iostream>
 
 #include "package.hpp"
 

--- a/libdnf/repo.hpp
+++ b/libdnf/repo.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <memory>
 
 #include "package.hpp"
 
@@ -27,12 +28,12 @@ class Repo {
 
 class RepoDict {
     private:
-        std::map<std::string, Repo> _repos;
+        std::map<std::string, std::shared_ptr<Repo>> _repos;
 
     public:
-        void set_repos(const std::map<std::string,Repo>& value);
-        const std::map<std::string,Repo>& get_repos();
-        void add_repo(Repo repo);
+        void set_repos(const std::map<std::string, std::shared_ptr<Repo>> & value);
+        const std::map<std::string, std::shared_ptr<Repo>> & get_repos();
+        void add_repo(std::shared_ptr<Repo> & repo);
 };
 
 #endif

--- a/libdnf/repo.hpp
+++ b/libdnf/repo.hpp
@@ -1,42 +1,39 @@
 #ifndef DNF_REPO_HPP
 #define DNF_REPO_HPP
 
-
 #include <string>
 #include <vector>
 #include <map>
 #include <functional>
 #include <iostream>
-using namespace std;
 
 #include "package.hpp"
 
 
-
 class Repo {
     private:
-        string _repoid;
-        string _name;
-        vector<string> _baseurl;
+        std::string _repoid;
+        std::string _name;
+        std::vector<std::string> _baseurl;
 
     public:
-        void set_repoid(const string & value);
-        const string& get_repoid();
+        void set_repoid(const std::string & value);
+        const std::string& get_repoid();
 
-        void set_baseurl(const vector<string>& value);
-        const vector<string>& get_baseurl();
+        void set_baseurl(const std::vector<std::string>& value);
+        const std::vector<std::string>& get_baseurl();
 
-        vector<Package *> packages;
+        std::vector<Package *> packages;
 };
 
 
 class RepoDict {
     private:
-        map<string, Repo> _repos;
+        std::map<std::string, Repo> _repos;
 
     public:
-        void set_repos(const map<string,Repo>& value);
-        const map<string,Repo>& get_repos();
+        void set_repos(const std::map<std::string,Repo>& value);
+        const std::map<std::string,Repo>& get_repos();
         void add_repo(Repo repo);
 };
 

--- a/libdnf/repo.i
+++ b/libdnf/repo.i
@@ -1,22 +1,23 @@
 %module repo
 
 
+%include <attribute.i>
+%include <std_string.i>
+%include <std_vector.i>
+%include <std_map.i>
+%include <std_shared_ptr.i>
+
+%shared_ptr(Repo)
+
 %{
     // make SWIG wrap following headers
     #include "repo.hpp"
 %}
 
-
-%include <attribute.i>
-%include <std_string.i>
-%include <std_vector.i>
-%include <std_map.i>
-
-
 namespace std {
     %template(list_string) vector<string>;
     %template(list_package) vector<Package*>;
-    %template() map<string, Repo>;
+    %template() map<string, shared_ptr<Repo>>;
 }
 
 

--- a/libdnf/repo.i
+++ b/libdnf/repo.i
@@ -25,5 +25,5 @@ namespace std {
 
 
 
-%attribute(Repo, string, repoid, get_repoid, set_repoid);
-%attribute(Repo, vector<string>&, baseurl, get_baseurl, set_baseurl);
+%attribute(Repo, std::string, repoid, get_repoid, set_repoid);
+%attribute(Repo, std::vector<std::string>&, baseurl, get_baseurl, set_baseurl);


### PR DESCRIPTION
- Removes "using namespace std;" from header files. (Now, I see mhatina did the same in his PR.)
- Removes unneeded "#include".
- Uses shared_ptr in RepoDict.