### PR TITLE
Use own namespace "libdnf" in C++

### DIFF
--- a/libdnf/package.i
+++ b/libdnf/package.i
@@ -3,7 +3,6 @@
 
 %{
     // make SWIG wrap following headers
-    #include "repo/repo.hpp"
     #include "package/package.hpp"
     #include "package/modulepackage.hpp"
     #include "package/rpmpackage.hpp"
@@ -11,8 +10,6 @@
 
 %include <attribute.i>
 %include <std_string.i>
-%include <std_vector.i>
-%include <std_map.i>
 %include <typemaps.i>
 
 // make SWIG look into following headers
@@ -20,38 +17,38 @@
 %include "package/modulepackage.hpp"
 %include "package/rpmpackage.hpp"
 
-%apply SWIGTYPE *DYNAMIC { Package * };
+%apply SWIGTYPE *DYNAMIC { libdnf::Package * };
 
 %{
 static swig_type_info *
 //Package_dynamic(void **ptr) {
-Package_dynamic(Package **ptr) {
-    RPMPackage *rpm;
-    rpm = dynamic_cast<RPMPackage *>(*ptr);
-    if (rpm) {
-        //*ptr = (void *) rpm;
-        return SWIGTYPE_p_RPMPackage;
-    }
+Package_dynamic(libdnf::Package **ptr) {
+   libdnf::RPMPackage *rpm;
+   rpm = dynamic_cast<libdnf::RPMPackage *>(*ptr);
+   if (rpm) {
+      //*ptr = (void *) rpm;
+      return SWIGTYPE_p_libdnf__RPMPackage;
+   }
 
-    ModulePackage *mod;
-    mod = dynamic_cast<ModulePackage *>(*ptr);
-    if (mod) {
-        //*ptr = (void *) mod;
-        return SWIGTYPE_p_ModulePackage;
-    }
+   libdnf::ModulePackage *mod;
+   mod = dynamic_cast<libdnf::ModulePackage *>(*ptr);
+   if (mod) {
+      //*ptr = (void *) mod;
+      return SWIGTYPE_p_libdnf__ModulePackage;
+   }
 
-    return 0;
+   return 0;
 }
 %}
 
 
 // register the above casting function
-DYNAMIC_CAST(SWIGTYPE_p_Package, Package_dynamic);
+DYNAMIC_CAST(SWIGTYPE_p_libdnf__Package, Package_dynamic);
 
 
-%extend Package {
-    bool __eq__(const Package &other) { return $self == &other; }
-    long __hash__() { return (long) $self; }  // hash: just address of C struct
+%extend libdnf::Package {
+   bool __eq__(const libdnf::Package &other) { return $self == &other; }
+   long __hash__() { return (long) $self; }  // hash: just address of C struct
 }
 
-%attribute(Package, std::string, name, getName, setName);
+%attribute(libdnf::Package, std::string, name, getName, setName);

--- a/libdnf/package/modulepackage.hpp
+++ b/libdnf/package/modulepackage.hpp
@@ -5,6 +5,8 @@
 
 #include "package.hpp"
 
+namespace libdnf {
+
 class ModulePackage : public Package {
 public:
     ModulePackage() = default;;
@@ -17,5 +19,7 @@ private:
     std::string stream;
     long long version;
 };
+
+}
 
 #endif //LIBDNF_MODULEPACKAGE_H

--- a/libdnf/package/package.hpp
+++ b/libdnf/package/package.hpp
@@ -3,6 +3,8 @@
 
 #include <string>
 
+namespace libdnf {
+
 class Package {
 public:
     Package() = default;
@@ -16,5 +18,7 @@ public:
 protected:
     std::string name;
 };
+
+}
 
 #endif

--- a/libdnf/package/rpmpackage.hpp
+++ b/libdnf/package/rpmpackage.hpp
@@ -5,6 +5,8 @@
 
 #include "package.hpp"
 
+namespace libdnf {
+
 class RPMPackage : public Package {
 public:
     RPMPackage() = default;
@@ -16,5 +18,7 @@ private:
     std::string version;
     std::string release;
 };
+
+}
 
 #endif //LIBDNF_RPMPACKAGE_H

--- a/libdnf/repo.i
+++ b/libdnf/repo.i
@@ -7,7 +7,7 @@
 %include <std_map.i>
 %include <std_shared_ptr.i>
 
-%shared_ptr(Repo)
+%shared_ptr(libdnf::Repo)
 
 %{
     // make SWIG wrap following headers
@@ -16,19 +16,17 @@
     #include "package/package.hpp"
 %}
 
-namespace std {
-    %template(list_string) vector<string>;
-    %template(list_package) vector<Package*>;
-    %template() map<string, shared_ptr<Repo> >;
-}
-
+%template(list_string) std::vector<std::string>;
+%template(list_package) std::vector<libdnf::Package*>;
+%template() std::map<std::string, std::shared_ptr<libdnf::Repo> >;
 
 // make SWIG look into following headers
 %include "repo/repo.hpp"
 %include "repo/repodict.hpp"
 %include "package/package.hpp"
 
+using libdnf::Package;
 
-%attribute(Repo, std::string, repoid, get_repoid, set_repoid);
-%attribute(Repo, std::vector<std::string>&, baseurl, get_baseurl, set_baseurl);
-%attribute(Repo, std::vector<Package *>&, packages, getPackages, setPackages);
+%attribute(libdnf::Repo, std::string, repoid, get_repoid, set_repoid);
+%attribute(libdnf::Repo, std::vector<std::string>&, baseurl, get_baseurl, set_baseurl);
+%attribute(libdnf::Repo, std::vector<libdnf::Package *>&, packages, getPackages, setPackages);

--- a/libdnf/repo/repo.cpp
+++ b/libdnf/repo/repo.cpp
@@ -5,6 +5,7 @@
 
 using namespace std;
 
+namespace libdnf {
 
 void Repo::set_repoid(const string &value) {
     repoid = value;
@@ -31,4 +32,6 @@ const std::vector<Package *> &Repo::getPackages() const {
 
 void Repo::setPackages(vector<Package *> &value) {
     packages = value;
+}
+
 }

--- a/libdnf/repo/repo.hpp
+++ b/libdnf/repo/repo.hpp
@@ -7,6 +7,8 @@
 
 #include "package.hpp"
 
+namespace libdnf {
+
 class Repo {
 public:
     void set_repoid(const std::string &value);
@@ -21,7 +23,8 @@ private:
     std::string name;
     std::vector<std::string> baseurl;
     std::vector<Package *> packages;
-
 };
+
+}
 
 #endif

--- a/libdnf/repo/repodict.cpp
+++ b/libdnf/repo/repodict.cpp
@@ -5,6 +5,8 @@
 
 using namespace std;
 
+namespace libdnf {
+
 void RepoDict::set_repos(const map<string, shared_ptr<Repo> > &value) {
     repos = value;
 }
@@ -17,3 +19,4 @@ void RepoDict::add_repo(shared_ptr<Repo> repo) {
     repos[repo->get_repoid()] = repo;
 }
 
+}

--- a/libdnf/repo/repodict.hpp
+++ b/libdnf/repo/repodict.hpp
@@ -6,6 +6,8 @@
 
 #include "repo.hpp"
 
+namespace libdnf {
+
 class RepoDict {
 public:
     void set_repos(const std::map<std::string, std::shared_ptr<Repo> > &value);
@@ -15,5 +17,7 @@ public:
 private:
     std::map <std::string, std::shared_ptr<Repo> > repos;
 };
+
+}
 
 #endif //LIBDNF_REPODICT_H


### PR DESCRIPTION
What about move our code from global into own namespace ("libdnf" in this example)?