### PR TITLE
Hide implementation of Repo class - PImpl

### DIFF
--- a/libdnf/repo/repo-private.hpp
+++ b/libdnf/repo/repo-private.hpp
@@ -1,13 +1,12 @@
-#ifndef DNF_REPO_HPP
-#define DNF_REPO_HPP
+#ifndef DNF_REPO_PRIVATE_HPP
+#define DNF_REPO_PRIVATE_HPP
 
-#include <memory>
 #include <string>
 #include <vector>
 
-#include "package.hpp"
+#include "repo.hpp"
 
-/// Class representing a repository.
+/// Nonpublic implementation part of class representing a repository.
 /**
  * Here goes the detailed description.
  * It can span multiple lines in the comment block.
@@ -15,36 +14,36 @@
  * Paragraphs are delimited with blank lines.
  * Markdown is supported.
  */
-class Repo {
+class Repo::Impl {
 public:
-    Repo();
-    ~Repo();
     /// Sets the id of this repository.
     /**
      * A more elaborate description of the setter.
      * \param value the string to use as the new id
      */
-    void set_repoid(const std::string &value);
+    void set_repoid(const std::string &value) { repoid = value; }
 
     /// Returns the id of this repository.
     /**
      * A more elaborate description of the getter.
      * \return the id of this repository
      */
-    const std::string &get_repoid() const;
+    const std::string &get_repoid() const { return repoid; }
 
     /// Sets the baseurl of this repository.
-    void set_baseurl(const std::vector<std::string> &value);
+    void set_baseurl(const std::vector<std::string> &value) { baseurl = value; }
     /// Returns the baseurl of this repository.
-    const std::vector<std::string> &get_baseurl() const;
+    const std::vector<std::string> &get_baseurl() const { return baseurl; }
     /// Returns the packages in this repository.
-    const std::vector<Package *> &getPackages() const;
+    const std::vector<Package *> &getPackages() const { return packages; }
     /// Sets the packages in this repository.
-    void setPackages(std::vector<Package *> &value);
+    void setPackages(std::vector<Package *> &value) { packages = value; }
 
 private:
-    class Impl;
-    const std::unique_ptr<Impl> pimpl;
+    std::string repoid;
+    std::string name;
+    std::vector<std::string> baseurl;
+    std::vector<Package *> packages;
 };
 
 #endif

--- a/libdnf/repo/repo.cpp
+++ b/libdnf/repo/repo.cpp
@@ -1,42 +1,46 @@
 #include <string>
 #include <vector>
 
-#include "repo.hpp"
+#include "repo-private.hpp"
 
 using namespace std;
+
+Repo::Repo() : pimpl{new Impl} {}
+
+Repo::~Repo() = default;
 
 void
 Repo::set_repoid(const string &value)
 {
-    repoid = value;
+    pimpl->set_repoid(value);
 }
 
 const string &
 Repo::get_repoid() const
 {
-    return repoid;
+    return pimpl->get_repoid();
 }
 
 void
 Repo::set_baseurl(const vector<string> &value)
 {
-    baseurl = value;
+    pimpl->set_baseurl(value);
 }
 
 const vector<string> &
 Repo::get_baseurl() const
 {
-    return baseurl;
+    return pimpl->get_baseurl();
 }
 
 const std::vector<Package *> &
 Repo::getPackages() const
 {
-    return packages;
+    return pimpl->getPackages();
 }
 
 void
 Repo::setPackages(vector<Package *> &value)
 {
-    packages = value;
+    pimpl->setPackages(value);
 }


### PR DESCRIPTION
Example of hiding implementation part of Repo class from public header file.
Standard PImpl method is used. Implementation is moved to private header file. Longer methods can be implemented in cpp file. Then private header contains only declaration of private method. Private class also can contain pointer back to to public class - it is sometime usefull.
If we do not need private class to be accessed from other private implementation files, then we don't need private header file and we can do declaration of private class in the cpp file.

PImpl idiom: Remove implementation details of a class from its object representation
by placing them in a separate class, accessed through an opaque pointer.